### PR TITLE
fix chrome issue

### DIFF
--- a/print.css
+++ b/print.css
@@ -21,3 +21,11 @@ table td {
   border-width: 1px;
   border-color: #ededed;
 }
+
+@media print {
+   thead {display: table-header-group;}
+}
+
+#csscheck {
+	display: none;
+}

--- a/renderers/Base.js
+++ b/renderers/Base.js
@@ -18,7 +18,22 @@ Ext.ux.Printer.BaseRenderer = Ext.extend(Object, {
     
     win.document.write(this.generateHTML(component));
     win.document.close();
-    
+
+    this.doPrintOnStylesheetLoad.defer(10, this, [win]);
+  },
+  
+  /**
+   * check if style is loaded and do print afterwards
+   * 
+   * @param {window} win
+   */
+  doPrintOnStylesheetLoad: function(win) {
+    var el = win.document.getElementById('csscheck'),
+        comp = el.currentStyle || getComputedStyle(el, null);
+    if (comp.display !== "none") {
+      this.doPrintOnStylesheetLoad.defer(10, this, [win]);
+      return;
+    }
     win.print();
     win.close();
   },
@@ -34,10 +49,11 @@ Ext.ux.Printer.BaseRenderer = Ext.extend(Object, {
       '<html>',
         '<head>',
           '<meta content="text/html; charset=UTF-8" http-equiv="Content-Type" />',
-          '<link href="' + this.stylesheetPath + '" rel="stylesheet" type="text/css" media="screen,print" />',
+          '<link href="' + this.stylesheetPath + '?' + new Date().getTime() + '" rel="stylesheet" type="text/css" media="screen,print" />',
           '<title>' + this.getTitle(component) + '</title>',
         '</head>',
         '<body>',
+          '<div id="csscheck"></div>',
           this.generateBody(component),
         '</body>',
       '</html>'


### PR DESCRIPTION
Hi Ed, 

I just added a simple 'css is loaded' detection, cause window.print() was called before the styes where loaded. This caused chrome (and may be others) not to print.

cu
cornelius
