### PR TITLE
Fix for Firefox 7 not writing HTML to the print window

### DIFF
--- a/renderers/Base.js
+++ b/renderers/Base.js
@@ -16,6 +16,9 @@ Ext.ux.Printer.BaseRenderer = Ext.extend(Object, {
              
     var win = window.open('', name);
     
+    win.document.write(this.generateHTML(component));
+    win.document.close();
+    
     // gecko looses its document after document.close(). but fortunally waits with printing till css is loaded itself
     if (Ext.isGecko) {
       win.print();
@@ -23,9 +26,6 @@ Ext.ux.Printer.BaseRenderer = Ext.extend(Object, {
       return;
     }
     
-    win.document.write(this.generateHTML(component));
-    win.document.close();
-
     this.doPrintOnStylesheetLoad.defer(10, this, [win]);
   },
   


### PR DESCRIPTION
On Firefox 7.0.1 on Windows Vista, I had to put the win.document.write and win.document.close lines above the check for Gecko or else Firefox would not show the HTML in the new window.
